### PR TITLE
Update invalid product slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ languages:
 - html
 products:
 - azure
-- azure-openai-service
-- azure-active-directory
+- azure-openai
+- active-directory
 - azure-cognitive-search
 - azure-app-service
 - azure-sdks


### PR DESCRIPTION
According to [doc](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#product), update invalid product slug `azure-openai-service` to `azure-openai`, and `azure-active-directory` to `active-directory`.

@hemarina, @dantelmomsft   for notification.