### PR TITLE
Allow assigning role to service principal

### DIFF
--- a/deploy/aca/infra/main.bicep
+++ b/deploy/aca/infra/main.bicep
@@ -83,8 +83,10 @@ param webAppExists bool = false
 param indexerAppExists bool = false
 
 
-@description('Id of the user to assign application roles for CLI to ingest documents')
-param userPrincipalId string = ''
+@description('Id of the user or app to assign application roles for CLI to ingest documents')
+param principalId string = ''
+@description('Type of the principal. Valid values: User,ServicePrincipal')
+param principalType string = 'User'
 
 @description('Use Application Insights for monitoring and performance tracing')
 param useApplicationInsights bool = false
@@ -413,9 +415,9 @@ module openAiRoleUser '../../shared/security/role.bicep'  = {
   scope: openAiResourceGroup
   name: 'openai-role-user'
   params: {
-    principalId: userPrincipalId
+    principalId: principalId
     roleDefinitionId: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -423,9 +425,9 @@ module formRecognizerRoleUser '../../shared/security/role.bicep' = {
   scope: formRecognizerResourceGroup
   name: 'formrecognizer-role-user'
   params: {
-    principalId: userPrincipalId
+    principalId: principalId
     roleDefinitionId: 'a97b65f3-24c7-4388-baec-2e87135dc908'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -433,9 +435,9 @@ module storageRoleUser '../../shared/security/role.bicep' = {
   scope: storageResourceGroup
   name: 'storage-role-user'
   params: {
-    principalId: userPrincipalId
+    principalId: principalId
     roleDefinitionId: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -443,9 +445,9 @@ module storageContribRoleUser '../../shared/security/role.bicep' = {
   scope: storageResourceGroup
   name: 'storage-contribrole-user'
   params: {
-    principalId: userPrincipalId
+    principalId: principalId
     roleDefinitionId: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -453,9 +455,9 @@ module searchRoleUser '../../shared/security/role.bicep' = {
   scope: searchServiceResourceGroup
   name: 'search-role-user'
   params: {
-    principalId: userPrincipalId
+    principalId: principalId
     roleDefinitionId: '1407120a-92aa-4202-b7e9-c0e197c71c8f'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -463,9 +465,9 @@ module searchContribRoleUser '../../shared/security/role.bicep' = {
   scope: searchServiceResourceGroup
   name: 'search-contrib-role-user'
   params: {
-    principalId: userPrincipalId
+    principalId: principalId
     roleDefinitionId: '8ebe5a00-799e-43f5-93ac-243d3dce84a7'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -473,9 +475,9 @@ module searchSvcContribRoleUser '../../shared/security/role.bicep' = {
   scope: searchServiceResourceGroup
   name: 'search-svccontrib-role-user'
   params: {
-    principalId: userPrincipalId
+    principalId: principalId
     roleDefinitionId: '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 

--- a/deploy/aca/infra/main.parameters.json
+++ b/deploy/aca/infra/main.parameters.json
@@ -11,8 +11,11 @@
     "location": {
       "value": "${AZURE_LOCATION}"
     },
-    "userPrincipalId": {
+    "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
+    },
+    "principalType": {
+      "value": "${AZURE_PRINCIPAL_TYPE}"
     },
     "openAiServiceName": {
       "value": "${AZURE_OPENAI_SERVICE}"

--- a/deploy/aks/infra/main.bicep
+++ b/deploy/aks/infra/main.bicep
@@ -82,6 +82,8 @@ param keyVaultName string = ''
 
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
+@description('Type of the principal. Valid values: User,ServicePrincipal')
+param principalType string = 'User'
 
 @description('Use Application Insights for monitoring and performance tracing')
 param useApplicationInsights bool = false
@@ -363,7 +365,7 @@ module storageContribRoleUser '../../shared/security/role.bicep' = {
   params: {
     principalId: principalId
     roleDefinitionId: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 

--- a/deploy/aks/infra/main.parameters.json
+++ b/deploy/aks/infra/main.parameters.json
@@ -14,6 +14,9 @@
     "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
     },
+    "principalType": {
+      "value": "${AZURE_PRINCIPAL_TYPE}"
+    },
     "openAiServiceName": {
       "value": "${AZURE_OPENAI_SERVICE}"
     },

--- a/deploy/app-service/infra/main.bicep
+++ b/deploy/app-service/infra/main.bicep
@@ -80,6 +80,8 @@ param allowedOrigin string = '' // should start with https://, shouldn't end wit
 
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
+@description('Type of the principal. Valid values: User,ServicePrincipal')
+param principalType string = 'User'
 
 @description('Use Application Insights for monitoring and performance tracing')
 param useApplicationInsights bool = false
@@ -321,7 +323,7 @@ module openAiRoleUser '../../shared/security/role.bicep' = if (openAiHost == 'az
   params: {
     principalId: principalId
     roleDefinitionId: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -331,7 +333,7 @@ module formRecognizerRoleUser '../../shared/security/role.bicep' = {
   params: {
     principalId: principalId
     roleDefinitionId: 'a97b65f3-24c7-4388-baec-2e87135dc908'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -341,7 +343,7 @@ module storageRoleUser '../../shared/security/role.bicep' = {
   params: {
     principalId: principalId
     roleDefinitionId: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -351,7 +353,7 @@ module storageContribRoleUser '../../shared/security/role.bicep' = {
   params: {
     principalId: principalId
     roleDefinitionId: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -361,7 +363,7 @@ module searchRoleUser '../../shared/security/role.bicep' = {
   params: {
     principalId: principalId
     roleDefinitionId: '1407120a-92aa-4202-b7e9-c0e197c71c8f'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -371,7 +373,7 @@ module searchContribRoleUser '../../shared/security/role.bicep' = {
   params: {
     principalId: principalId
     roleDefinitionId: '8ebe5a00-799e-43f5-93ac-243d3dce84a7'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 
@@ -381,7 +383,7 @@ module searchSvcContribRoleUser '../../shared/security/role.bicep' = {
   params: {
     principalId: principalId
     roleDefinitionId: '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
-    principalType: 'User'
+    principalType: principalType
   }
 }
 

--- a/deploy/app-service/infra/main.parameters.json
+++ b/deploy/app-service/infra/main.parameters.json
@@ -14,6 +14,9 @@
     "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
     },
+    "principalType": {
+      "value": "${AZURE_PRINCIPAL_TYPE}"
+    },
     "openAiServiceName": {
       "value": "${AZURE_OPENAI_SERVICE}"
     },


### PR DESCRIPTION
## Purpose
Running `azd up` in CD environments with service principal is blocked by the error: UnmatchedPrincipalType: `The PrincipalId '***' has type 'ServicePrincipal' , which is different from specified PrinciaplType 'User'.`
This PR is to update the bicep to allow assigning roles to service principal.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Login azd with service principal.
```
azd auth login --client-id *** --client-secret *** --tenant-id ***
azd up
```

## What to Check
Verify that the following are valid
* `azd up` should succeed

## Other Information
<!-- Add any other helpful information that may be needed here. -->